### PR TITLE
Use atomic instead of mutex

### DIFF
--- a/sync/wg_cancel.go
+++ b/sync/wg_cancel.go
@@ -51,10 +51,10 @@ func (wg *CancelableWaitGroup) Add(n int) {
 
 	for (wg.cur + n) > wg.cap {
 		wg.cond.Wait()
-	}
 
-	if atomic.LoadInt32(&wg.done) == 1 {
-		return
+		if atomic.LoadInt32(&wg.done) == 1 {
+			return
+		}
 	}
 
 	wg.cur += n

--- a/sync/wg_cancel.go
+++ b/sync/wg_cancel.go
@@ -43,7 +43,7 @@ func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGro
 // However, it does return if the context is canceled.
 func (wg *CancelableWaitGroup) Add(n int) {
 	if n > wg.cap {
-		panic("trying to add more than cap")
+		panic("libqd/sync: tryng to Add more than cap")
 	}
 
 	wg.mu.Lock()
@@ -66,7 +66,7 @@ func (wg *CancelableWaitGroup) Done() {
 	defer wg.mu.Unlock()
 
 	if wg.cur == 0 {
-		panic("called Done more than Add")
+		panic("libqd/sync: called Done more than Add")
 	}
 
 	if atomic.LoadInt32(&wg.done) == 1 {

--- a/sync/wg_cancel.go
+++ b/sync/wg_cancel.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 type CancelableWaitGroup struct {
@@ -11,8 +12,7 @@ type CancelableWaitGroup struct {
 	cap     int
 	cur     int
 	context context.Context
-	done    bool
-	doneMu  sync.RWMutex
+	done    int32
 }
 
 // NewCancelableWaitGroup returns a Waiter that can be canceled wia a context.
@@ -23,8 +23,7 @@ func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGro
 		mu:      sync.Mutex{},
 		cap:     cap,
 		context: context,
-		done:    false,
-		doneMu:  sync.RWMutex{},
+		done:    0,
 	}
 
 	wg.cond = sync.NewCond(&wg.mu)
@@ -32,10 +31,7 @@ func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGro
 	go func() {
 		select {
 		case <-wg.context.Done():
-			wg.doneMu.Lock()
-			defer wg.doneMu.Unlock()
-			wg.done = true
-
+			atomic.SwapInt32(&wg.done, 1)
 			wg.cond.Broadcast()
 		}
 	}()
@@ -46,6 +42,10 @@ func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGro
 // Add adds n tasks and does not return until wg.cur + n <= wg.cap.
 // However, it does return if the context is canceled.
 func (wg *CancelableWaitGroup) Add(n int) {
+	if n > wg.cap {
+		panic("trying to add more than cap")
+	}
+
 	wg.mu.Lock()
 	defer wg.mu.Unlock()
 
@@ -53,13 +53,7 @@ func (wg *CancelableWaitGroup) Add(n int) {
 		wg.cond.Wait()
 	}
 
-	done := func() bool {
-		wg.doneMu.RLock()
-		defer wg.doneMu.RUnlock()
-		return wg.done
-	}()
-
-	if done {
+	if atomic.LoadInt32(&wg.done) == 1 {
 		return
 	}
 
@@ -72,16 +66,10 @@ func (wg *CancelableWaitGroup) Done() {
 	defer wg.mu.Unlock()
 
 	if wg.cur == 0 {
-		return
+		panic("called Done more than Add")
 	}
 
-	done := func() bool {
-		wg.doneMu.RLock()
-		defer wg.doneMu.RUnlock()
-		return wg.done
-	}()
-
-	if done {
+	if atomic.LoadInt32(&wg.done) == 1 {
 		return
 	}
 
@@ -98,13 +86,7 @@ func (wg *CancelableWaitGroup) Wait() {
 	for wg.cur > 0 {
 		wg.cond.Wait()
 
-		done := func() bool {
-			wg.doneMu.RLock()
-			defer wg.doneMu.RUnlock()
-			return wg.done
-		}()
-
-		if done {
+		if atomic.LoadInt32(&wg.done) == 1 {
 			return
 		}
 	}

--- a/sync/wg_cancel_test.go
+++ b/sync/wg_cancel_test.go
@@ -68,7 +68,7 @@ func TestCancelableWaitGroupDone(t *testing.T) {
 		}
 	}
 
-	for i := cap; i >= -3; i-- {
+	for i := wg.cur; i > 0; i-- {
 		//t.Logf("Reverse Loop #%d: wg.Done()", i)
 
 		go doneFunc()


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>