### PR TITLE
Fix go routine leak

### DIFF
--- a/sync/wg_cancel.go
+++ b/sync/wg_cancel.go
@@ -6,33 +6,47 @@ import (
 	"sync/atomic"
 )
 
+// CancelableWaitGroup is a Waiter that can be canceled via a context.
+// If the context is canceled then Waiter.Wait() will return even if Waiter.Done()
+// has not been called as much as Waiter.Add().
+// Note that this waiter can only be used once. If Add() is used after the context
+// has been canceled or after Done() has been called as much as Add() then it will panic.
 type CancelableWaitGroup struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
-	cap     int
-	cur     int
 	context context.Context
-	done    int32
+
+	// max number of tasks
+	cap int
+	// current number of tasks
+	cur int
+
+	// atomic integers used as boolean
+	finalized int32
+
+	// this chan is used to release the go routine when the wait group is finalized
+	// when Wait() detects that wg.cur == 0
+	ch chan struct{}
 }
 
-// NewCancelableWaitGroup returns a Waiter that can be canceled via a context.
-// If the context is canceled then Waiter.Wait() will return even if Waiter.Done()
-// has not been called as much as Waiter.Add().
+// NewCancelableWaitGroup returns a CancelableWaitGroup which has been initialized.
 func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGroup {
 	wg := &CancelableWaitGroup{
-		mu:      sync.Mutex{},
-		cap:     cap,
-		context: context,
-		done:    0,
+		mu:        sync.Mutex{},
+		cap:       cap,
+		context:   context,
+		finalized: 0,
+		ch:        make(chan struct{}, 1),
 	}
 
 	wg.cond = sync.NewCond(&wg.mu)
 
 	go func() {
-		//nolint:gosimple
 		select {
+		case <-wg.ch:
+			// Go routine is released when wg.cur comes back to zero
 		case <-wg.context.Done():
-			atomic.SwapInt32(&wg.done, 1)
+			atomic.SwapInt32(&wg.finalized, 1)
 			wg.cond.Broadcast()
 		}
 	}()
@@ -44,7 +58,11 @@ func NewCancelableWaitGroup(context context.Context, cap int) *CancelableWaitGro
 // However, it does return if the context is canceled.
 func (wg *CancelableWaitGroup) Add(n int) {
 	if n > wg.cap {
-		panic("libqd/sync: tryng to Add more than cap")
+		panic("libqd/sync: trying to Add more than cap")
+	}
+
+	if atomic.LoadInt32(&wg.finalized) == 1 {
+		panic("libqd/sync: wait group has been finalized and can't be re-used")
 	}
 
 	wg.mu.Lock()
@@ -53,7 +71,7 @@ func (wg *CancelableWaitGroup) Add(n int) {
 	for (wg.cur + n) > wg.cap {
 		wg.cond.Wait()
 
-		if atomic.LoadInt32(&wg.done) == 1 {
+		if atomic.LoadInt32(&wg.finalized) == 1 {
 			return
 		}
 	}
@@ -67,10 +85,10 @@ func (wg *CancelableWaitGroup) Done() {
 	defer wg.mu.Unlock()
 
 	if wg.cur == 0 {
-		panic("libqd/sync: called Done more than Add")
+		panic("libqd/sync: called Done() more than Add()")
 	}
 
-	if atomic.LoadInt32(&wg.done) == 1 {
+	if atomic.LoadInt32(&wg.finalized) == 1 {
 		return
 	}
 
@@ -82,12 +100,17 @@ func (wg *CancelableWaitGroup) Done() {
 // Wait waits until the number of tasks is 0 or until the context is canceled.
 func (wg *CancelableWaitGroup) Wait() {
 	wg.mu.Lock()
-	defer wg.mu.Unlock()
+
+	defer func() {
+		atomic.SwapInt32(&wg.finalized, 1)
+		wg.ch <- struct{}{}
+		wg.mu.Unlock()
+	}()
 
 	for wg.cur > 0 {
 		wg.cond.Wait()
 
-		if atomic.LoadInt32(&wg.done) == 1 {
+		if atomic.LoadInt32(&wg.finalized) == 1 {
 			return
 		}
 	}


### PR DESCRIPTION
The context watching go routine is not released when the wait group is
finalized using Done().